### PR TITLE
Fix crash on 32 bit unity games

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -439,7 +439,10 @@ namespace UnhollowerRuntimeLib
             if (targetMethod == IntPtr.Zero)
                 return;
 
-            ourOriginalTypeToClassMethod = Detour.Detour(targetMethod, new TypeToClassDelegate(ClassFromTypePatch));
+            IntPtr* targetVarPointer = &targetMethod;
+            DoHook((IntPtr)targetVarPointer,
+                Marshal.GetFunctionPointerForDelegate(new TypeToClassDelegate(ClassFromTypePatch)));
+            ourOriginalTypeToClassMethod = Marshal.GetDelegateForFunctionPointer<TypeToClassDelegate>(targetMethod);
             LogSupport.Trace("il2cpp_class_from_il2cpp_type patched");
         }
 

--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -439,10 +439,7 @@ namespace UnhollowerRuntimeLib
             if (targetMethod == IntPtr.Zero)
                 return;
 
-            IntPtr* targetVarPointer = &targetMethod;
-            DoHook((IntPtr)targetVarPointer,
-                Marshal.GetFunctionPointerForDelegate(new TypeToClassDelegate(ClassFromTypePatch)));
-            ourOriginalTypeToClassMethod = Marshal.GetDelegateForFunctionPointer<TypeToClassDelegate>(targetMethod);
+            ourOriginalTypeToClassMethod = Detour.Detour(targetMethod, new TypeToClassDelegate(ClassFromTypePatch));
             LogSupport.Trace("il2cpp_class_from_il2cpp_type patched");
         }
 

--- a/UnhollowerBaseLib/Runtime/Il2CppStructs.cs
+++ b/UnhollowerBaseLib/Runtime/Il2CppStructs.cs
@@ -396,12 +396,6 @@ namespace UnhollowerBaseLib.Runtime
     [StructLayout(LayoutKind.Sequential)]
     public struct Il2CppClassPart2
     {
-        public uint initializationExceptionGCHandle;
-
-        public uint cctor_started;
-        public uint cctor_finished;
-        public /*ALIGN_TYPE(8)*/IntPtr cctor_thread;
-
         // Remaining fields are always valid except where noted
         public /*GenericContainerIndex*/ int genericContainerIndex;
         public uint instance_size;
@@ -427,12 +421,6 @@ namespace UnhollowerBaseLib.Runtime
     [StructLayout(LayoutKind.Sequential)]
     public struct Il2CppClassPart2_32
     {
-        public uint initializationExceptionGCHandle;
-
-        public uint cctor_started;
-        public uint cctor_finished;
-        public int cctor_thread;
-
         // Remaining fields are always valid except where noted
         public /*GenericContainerIndex*/ int genericContainerIndex;
         public uint instance_size;

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Unity2018_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Unity2018_0.cs
@@ -39,6 +39,10 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific
         private struct Il2CppClassU2018_0
         {
             public Il2CppClassPart1 Part1;
+            public uint initializationExceptionGCHandle;
+            public uint cctor_started;
+            public uint cctor_finished;
+            public /*ALIGN_TYPE(8)*/ulong cctor_thread;
             public Il2CppClassPart2 Part2;
             public byte typeHierarchyDepth; // Initialized in SetupTypeHierachy
             public byte genericRecursionDepth;

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Unity2018_4.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Unity2018_4.cs
@@ -38,6 +38,10 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific
         private struct Il2CppClassU2018_4
         {
             public Il2CppClassPart1 Part1;
+            public uint initializationExceptionGCHandle;
+            public uint cctor_started;
+            public uint cctor_finished;
+            public /*ALIGN_TYPE(8)*/ulong cctor_thread;
             public Il2CppClassPart2 Part2;
             public byte typeHierarchyDepth; // Initialized in SetupTypeHierachy
             public byte genericRecursionDepth;

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Unity2019.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Unity2019.cs
@@ -13,8 +13,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific
             LogSupport.Trace($"klass Offset:       {(byte*)&ex.Part1.klass - addr}");
             LogSupport.Trace($"typeHierarchy Offset:       {(byte*)&ex.Part1.typeHierarchy - addr}");
             LogSupport.Trace($"unity_user_data Offset:       {(byte*)&ex.unity_user_data - addr}");
-            LogSupport.Trace($"cctor_finished Offset:       {(byte*)&ex.Part2.cctor_finished - addr}");
-            LogSupport.Trace($"cctor_thread Offset:       {(byte*)&ex.Part2.cctor_thread - addr}");
+            LogSupport.Trace($"cctor_finished Offset:       {(byte*)&ex.cctor_finished - addr}");
+            LogSupport.Trace($"cctor_thread Offset:       {(byte*)&ex.cctor_thread - addr}");
             LogSupport.Trace($"genericContainerIndex Offset:       {(byte*)&ex.Part2.genericContainerIndex - addr}");
             LogSupport.Trace($"field_count Offset:       {(byte*)&ex.Part2.field_count - addr}");
             LogSupport.Trace($"interface_offsets_count Offset:       {(byte*)&ex.Part2.interface_offsets_count - addr}");
@@ -65,6 +65,10 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific
         {
             public Il2CppClassPart1 Part1;
             public IntPtr unity_user_data;
+            public uint initializationExceptionGCHandle;
+            public uint cctor_started;
+            public uint cctor_finished;
+            public /*ALIGN_TYPE(8)*/IntPtr cctor_thread;
             public Il2CppClassPart2 Part2;
             public byte typeHierarchyDepth; // Initialized in SetupTypeHierachy
             public byte genericRecursionDepth;
@@ -101,12 +105,16 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific
             public ClassBitfield1* Bitfield1 => &Instance->bitfield_1;
             public ClassBitfield2* Bitfield2 => &Instance->bitfield_2;
         }
-        
-        [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 192)]
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1, Size =188)]
         private struct Il2CppClassU2019_32
         {
             public Il2CppClassPart1 Part1;
             public int unity_user_data;
+            public uint initializationExceptionGCHandle;
+            public uint cctor_started;
+            public uint cctor_finished;
+            public /*ALIGN_TYPE(8)*/IntPtr cctor_thread;
             public Il2CppClassPart2_32 Part2;
             public byte typeHierarchyDepth; // Initialized in SetupTypeHierachy
             public byte genericRecursionDepth;


### PR DESCRIPTION
Revert class injector detour
Fix 2019 32 bit struct layout, change size from 192 to 188 bytes.
Fix 2018 32 bit struct layout, change cctor_thread from 4 bytes to 8 bytes.