### PR TITLE
Better Class::Init Search Method

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -774,13 +774,6 @@ namespace UnhollowerRuntimeLib
         private delegate void ClassInitDelegate(Il2CppClass* klass);
         private static ClassInitDelegate ourClassInitMethod;
 
-        private struct SignatureDefinition
-        {
-            public string pattern;
-            public string mask;
-            public int offset;
-            public bool xref;
-        }
         private static readonly SignatureDefinition[] classInitSignatures =
         {
             new SignatureDefinition

--- a/UnhollowerBaseLib/MemoryUtils.cs
+++ b/UnhollowerBaseLib/MemoryUtils.cs
@@ -1,4 +1,9 @@
-﻿namespace UnhollowerBaseLib
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using UnhollowerRuntimeLib.XrefScans;
+
+namespace UnhollowerBaseLib
 {
     internal class MemoryUtils
     {
@@ -8,6 +13,19 @@
             public string mask;
             public int offset;
             public bool xref;
+        }
+        public static unsafe void* FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
+        {
+            void* ptr = FindSignatureInBlock(
+                module.BaseAddress.ToPointer(),
+                module.ModuleMemorySize,
+                sigDef.pattern,
+                sigDef.mask,
+                sigDef.offset
+            );
+            if (ptr != (void*)0 && sigDef.xref)
+                ptr = XrefScannerLowLevel.JumpTargets((IntPtr)ptr).FirstOrDefault().ToPointer();
+            return ptr;
         }
 
         public static unsafe void* FindSignatureInBlock(void* block, long blockSize, string pattern, string mask, long sigOffset = 0)

--- a/UnhollowerBaseLib/MemoryUtils.cs
+++ b/UnhollowerBaseLib/MemoryUtils.cs
@@ -2,6 +2,14 @@
 {
     internal class MemoryUtils
     {
+        private struct SignatureDefinition
+        {
+            public string pattern;
+            public string mask;
+            public int offset;
+            public bool xref;
+        }
+
         public static unsafe void* FindSignatureInBlock(void* block, long blockSize, string pattern, string mask, long sigOffset = 0)
             => FindSignatureInBlock(block, blockSize, pattern.ToCharArray(), mask.ToCharArray(), sigOffset);
         public static unsafe void* FindSignatureInBlock(void* block, long blockSize, char[] pattern, char[] mask, long sigOffset = 0)

--- a/UnhollowerBaseLib/MemoryUtils.cs
+++ b/UnhollowerBaseLib/MemoryUtils.cs
@@ -1,0 +1,26 @@
+﻿namespace UnhollowerBaseLib
+{
+    internal class MemoryUtils
+    {
+        public static unsafe void* FindSignatureInBlock(void* block, long blockSize, string pattern, string mask, long sigOffset = 0)
+            => FindSignatureInBlock(block, blockSize, pattern.ToCharArray(), mask.ToCharArray(), sigOffset);
+        public static unsafe void* FindSignatureInBlock(void* block, long blockSize, char[] pattern, char[] mask, long sigOffset = 0)
+        {
+            for (long address = 0; address < blockSize; address++)
+            {
+                bool found = true;
+                for (uint offset = 0; offset < mask.Length; offset++)
+                {
+                    if (((*(byte*)(address + (long)block + offset)) != (byte)pattern[offset]) && mask[offset] != '?')
+                    {
+                        found = false;
+                        break;
+                    }
+                }
+                if (found)
+                    return (void*)(address + (long)block + sigOffset);
+            }
+            return (void*)0;
+        }
+    }
+}

--- a/UnhollowerBaseLib/MemoryUtils.cs
+++ b/UnhollowerBaseLib/MemoryUtils.cs
@@ -14,39 +14,39 @@ namespace UnhollowerBaseLib
             public int offset;
             public bool xref;
         }
-        public static unsafe void* FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
+        public static unsafe nint FindSignatureInModule(ProcessModule module, SignatureDefinition sigDef)
         {
-            void* ptr = FindSignatureInBlock(
-                module.BaseAddress.ToPointer(),
+            nint ptr = FindSignatureInBlock(
+                module.BaseAddress,
                 module.ModuleMemorySize,
                 sigDef.pattern,
                 sigDef.mask,
                 sigDef.offset
             );
-            if (ptr != (void*)0 && sigDef.xref)
-                ptr = XrefScannerLowLevel.JumpTargets((IntPtr)ptr).FirstOrDefault().ToPointer();
+            if (ptr != 0 && sigDef.xref)
+                ptr = XrefScannerLowLevel.JumpTargets(ptr).FirstOrDefault();
             return ptr;
         }
 
-        public static unsafe void* FindSignatureInBlock(void* block, long blockSize, string pattern, string mask, long sigOffset = 0)
+        public static unsafe nint FindSignatureInBlock(nint block, long blockSize, string pattern, string mask, long sigOffset = 0)
             => FindSignatureInBlock(block, blockSize, pattern.ToCharArray(), mask.ToCharArray(), sigOffset);
-        public static unsafe void* FindSignatureInBlock(void* block, long blockSize, char[] pattern, char[] mask, long sigOffset = 0)
+        public static unsafe nint FindSignatureInBlock(nint block, long blockSize, char[] pattern, char[] mask, long sigOffset = 0)
         {
             for (long address = 0; address < blockSize; address++)
             {
                 bool found = true;
                 for (uint offset = 0; offset < mask.Length; offset++)
                 {
-                    if (((*(byte*)(address + (long)block + offset)) != (byte)pattern[offset]) && mask[offset] != '?')
+                    if (((*(byte*)(address + block + offset)) != (byte)pattern[offset]) && mask[offset] != '?')
                     {
                         found = false;
                         break;
                     }
                 }
                 if (found)
-                    return (void*)(address + (long)block + sigOffset);
+                    return (nint)(address + block + sigOffset);
             }
-            return (void*)0;
+            return 0;
         }
     }
 }

--- a/UnhollowerBaseLib/MemoryUtils.cs
+++ b/UnhollowerBaseLib/MemoryUtils.cs
@@ -2,7 +2,7 @@
 {
     internal class MemoryUtils
     {
-        private struct SignatureDefinition
+        public struct SignatureDefinition
         {
             public string pattern;
             public string mask;


### PR DESCRIPTION
Implements a signature scanner to scan for premade signatures pointing to `Class::Init`.
Defaults to `il2cpp_class_has_references` if none of the signatures work.

*NOTE:* **il2cpp_class_has_references has a race condition with calling `Class::Init` but it will still allow games to run and inject their classes into il2cpp instead of failing like before**