### PR TITLE
Fix TryCast and default constructor calling issues

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -556,7 +556,6 @@ namespace UnhollowerRuntimeLib
             }
             else
             {
-                var defaultCtor = targetType.GetConstructor(Array.Empty<Type>());
                 var local = body.DeclareLocal(targetType);
                 body.Emit(OpCodes.Ldtoken, targetType);
                 body.Emit(OpCodes.Call, typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle), BindingFlags.Public | BindingFlags.Static)!);

--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
 using UnhollowerBaseLib;
@@ -555,9 +556,11 @@ namespace UnhollowerRuntimeLib
             }
             else
             {
-                var local = body.DeclareLocal(targetType);
                 var defaultCtor = targetType.GetConstructor(Array.Empty<Type>());
-                body.Emit(OpCodes.Newobj, defaultCtor);
+                var local = body.DeclareLocal(targetType);
+                body.Emit(OpCodes.Ldtoken, targetType);
+                body.Emit(OpCodes.Call, typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle), BindingFlags.Public | BindingFlags.Static)!);
+                body.Emit(OpCodes.Call, typeof(FormatterServices).GetMethod(nameof(FormatterServices.GetUninitializedObject), BindingFlags.Public | BindingFlags.Static)!);
                 body.Emit(OpCodes.Stloc, local);
                 body.Emit(OpCodes.Ldloc, local);
                 body.Emit(OpCodes.Ldarg_0);

--- a/UnhollowerBaseLib/Il2CppObjectBase.cs
+++ b/UnhollowerBaseLib/Il2CppObjectBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization;
 using UnhollowerBaseLib.Runtime;
 
 namespace UnhollowerBaseLib
@@ -76,8 +77,16 @@ namespace UnhollowerBaseLib
                 var monoObject = ClassInjectorBase.GetMonoObjectFromIl2CppPointer(Pointer) as T;
                 if (monoObject != null) return monoObject;
             }
-            
-            return (T) Activator.CreateInstance(Il2CppClassPointerStore<T>.CreatedTypeRedirect ?? typeof(T), Pointer);
+
+            Type type = Il2CppClassPointerStore<T>.CreatedTypeRedirect ?? typeof(T);
+            if (type.GetConstructor(new Type[] { typeof(IntPtr) }) != null)
+                return (T)Activator.CreateInstance(type, Pointer);
+            else
+            {
+                T obj = (T)FormatterServices.GetUninitializedObject(type);
+                obj.CreateGCHandle(Pointer);
+                return obj;
+            }
         }
 
         ~Il2CppObjectBase()


### PR DESCRIPTION
Fixes #19's issue which causes TryCast to fail if an IntPtr constructor is missing and modifies `CreateEmptyCtor` to not call the default constructor.