### PR TITLE
Support injecting fields in il2cpp domain

### DIFF
--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -209,7 +209,7 @@ namespace UnhollowerRuntimeLib
             classPointer.IsVtableInitialized = true;
 
             classPointer.Name = Marshal.StringToHGlobalAnsi(type.Name);
-            classPointer.Namespace = Marshal.StringToHGlobalAnsi(type.Namespace);
+            classPointer.Namespace = Marshal.StringToHGlobalAnsi(type.Namespace ?? string.Empty);
 
             classPointer.ThisArg.Type = classPointer.ByValArg.Type = Il2CppTypeEnum.IL2CPP_TYPE_CLASS;
             classPointer.ThisArg.ByRef = true;

--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -102,12 +102,10 @@ namespace UnhollowerRuntimeLib
         {
             var handleAsPointer = GCHandle.ToIntPtr(gcHandle);
             if (pointer == IntPtr.Zero) throw new NullReferenceException(nameof(pointer));
-            var objectKlass = (Il2CppClass*)IL2CPP.il2cpp_object_get_class(pointer);
-            var targetGcHandlePointer = IntPtr.Add(pointer, (int)UnityVersionHandler.Wrap(objectKlass).InstanceSize - IntPtr.Size);
-            *(IntPtr*)targetGcHandlePointer = handleAsPointer;
+            ClassInjectorBase.GetInjectedData(pointer)->managedGcHandle = GCHandle.ToIntPtr(gcHandle);
         }
 
-
+            
         public static bool IsTypeRegisteredInIl2Cpp<T>() where T : class => IsTypeRegisteredInIl2Cpp(typeof(T));
         public static bool IsTypeRegisteredInIl2Cpp(Type type)
         {
@@ -202,7 +200,7 @@ namespace UnhollowerRuntimeLib
             classPointer.Parent = baseClassPointer.ClassPointer;
             classPointer.ElementClass = classPointer.Class = classPointer.CastClass = classPointer.ClassPointer;
             classPointer.NativeSize = -1;
-            classPointer.ActualSize = classPointer.InstanceSize = baseClassPointer.InstanceSize + (uint)IntPtr.Size;
+            classPointer.ActualSize = classPointer.InstanceSize = (uint)(baseClassPointer.InstanceSize + sizeof(InjectedClassData));
 
             classPointer.Initialized = true;
             classPointer.InitializedAndNoError = true;

--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -96,6 +96,18 @@ namespace UnhollowerRuntimeLib
         {
             if (objectBase.isWrapped)
                 return;
+            FieldInfo[] fields = objectBase.GetType()
+                 .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                 .Where(IsFieldEligible)
+                 .ToArray();
+            foreach (FieldInfo field in fields)
+            {
+                field.SetValue(objectBase, field.FieldType.GetConstructor(
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null,
+                    new Type[] { typeof(Il2CppObjectBase), typeof(string) }, Array.Empty<ParameterModifier>())
+                    .Invoke(new object[] { objectBase, field.Name })
+                );
+            }
             var ownGcHandle = GCHandle.Alloc(objectBase, GCHandleType.Normal);
             AssignGcHandle(objectBase.Pointer, ownGcHandle);
         }

--- a/UnhollowerBaseLib/ClassInjector.cs
+++ b/UnhollowerBaseLib/ClassInjector.cs
@@ -14,7 +14,9 @@ using UnhollowerBaseLib.Attributes;
 using UnhollowerBaseLib.Runtime;
 using UnhollowerBaseLib.Runtime.VersionSpecific.Assembly;
 using UnhollowerBaseLib.Runtime.VersionSpecific.Class;
+using UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo;
 using UnhollowerBaseLib.Runtime.VersionSpecific.Image;
+using UnhollowerBaseLib.Runtime.VersionSpecific.Type;
 using UnhollowerRuntimeLib.XrefScans;
 using Void = Il2CppSystem.Void;
 
@@ -30,7 +32,7 @@ namespace UnhollowerRuntimeLib
         {
             return interfaces.Select(it =>
             {
-                var classPointer = ClassInjector.ReadClassPointerForType(it);
+                var classPointer = Il2CppClassPointerStore.GetNativeClassPointer(it);
                 if (classPointer == IntPtr.Zero)
                     throw new ArgumentException(
                         $"Type {it} doesn't have an IL2CPP class pointer, which means it's not an IL2CPP interface");
@@ -109,7 +111,7 @@ namespace UnhollowerRuntimeLib
         public static bool IsTypeRegisteredInIl2Cpp<T>() where T : class => IsTypeRegisteredInIl2Cpp(typeof(T));
         public static bool IsTypeRegisteredInIl2Cpp(Type type)
         {
-            var currentPointer = ReadClassPointerForType(type);
+            var currentPointer = Il2CppClassPointerStore.GetNativeClassPointer(type);
             if (currentPointer != IntPtr.Zero)
                 return true;
             lock (InjectedTypes)
@@ -150,7 +152,7 @@ namespace UnhollowerRuntimeLib
             if (type.IsGenericType || type.IsGenericTypeDefinition)
                 throw new ArgumentException($"Type {type} is generic and can't be used in il2cpp");
 
-            var currentPointer = ReadClassPointerForType(type);
+            var currentPointer = Il2CppClassPointerStore.GetNativeClassPointer(type);
             if (currentPointer != IntPtr.Zero)
                 return; //already registered in il2cpp
 
@@ -158,11 +160,11 @@ namespace UnhollowerRuntimeLib
             if (baseType == null)
                 throw new ArgumentException($"Class {type} does not inherit from a class registered in il2cpp");
 
-            var baseClassPointer = UnityVersionHandler.Wrap((Il2CppClass*)ReadClassPointerForType(baseType));
+            var baseClassPointer = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore.GetNativeClassPointer(baseType));
             if (baseClassPointer == null)
             {
                 RegisterTypeInIl2Cpp(baseType, new RegisterTypeOptions() { LogSuccess = options.LogSuccess });
-                baseClassPointer = UnityVersionHandler.Wrap((Il2CppClass*)ReadClassPointerForType(baseType));
+                baseClassPointer = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore.GetNativeClassPointer(baseType));
             }
 
             // Initialize the vtable of all base types (Class::Init is recursive internally)
@@ -200,7 +202,7 @@ namespace UnhollowerRuntimeLib
             classPointer.Parent = baseClassPointer.ClassPointer;
             classPointer.ElementClass = classPointer.Class = classPointer.CastClass = classPointer.ClassPointer;
             classPointer.NativeSize = -1;
-            classPointer.ActualSize = classPointer.InstanceSize = (uint)(baseClassPointer.InstanceSize + sizeof(InjectedClassData));
+            classPointer.ActualSize = classPointer.InstanceSize = baseClassPointer.InstanceSize;
 
             classPointer.Initialized = true;
             classPointer.InitializedAndNoError = true;
@@ -216,6 +218,54 @@ namespace UnhollowerRuntimeLib
 
             classPointer.Flags = baseClassPointer.Flags; // todo: adjust flags?
 
+            FieldInfo[] fieldsToInject = type
+                .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                .Where(IsFieldEligible)
+                .ToArray();
+            classPointer.FieldCount = (ushort)fieldsToInject.Length;
+
+            Il2CppFieldInfo* il2cppFields = (Il2CppFieldInfo*)Marshal.AllocHGlobal(classPointer.FieldCount * UnityVersionHandler.FieldInfoSize());
+            int fieldOffset = (int)classPointer.InstanceSize;
+            for (int i = 0; i < classPointer.FieldCount; i++) {
+                INativeFieldInfoStruct fieldInfo = UnityVersionHandler.Wrap(il2cppFields + (i * UnityVersionHandler.FieldInfoSize()));
+                fieldInfo.Name = Marshal.StringToHGlobalAnsi(fieldsToInject[i].Name);
+                fieldInfo.Parent = classPointer.ClassPointer;
+                fieldInfo.Offset = fieldOffset;
+
+                Type fieldType = fieldsToInject[i].FieldType.GenericTypeArguments[0];
+                FieldAttributes fieldAttributes = fieldsToInject[i].Attributes;
+                IntPtr fieldInfoClass = Il2CppClassPointerStore.GetNativeClassPointer(fieldType);
+                if (!_injectedFieldTypes.TryGetValue((fieldType, fieldAttributes), out IntPtr fieldTypePtr)) {
+                    INativeTypeStruct classType = UnityVersionHandler.Wrap((Il2CppTypeStruct*)IL2CPP.il2cpp_class_get_type(fieldInfoClass));
+
+                    INativeTypeStruct duplicatedType = UnityVersionHandler.NewType();
+                    duplicatedType.Data = classType.Data;
+                    duplicatedType.Attrs = (ushort)fieldAttributes;
+                    duplicatedType.Type = classType.Type;
+                    duplicatedType.ByRef = classType.ByRef;
+                    duplicatedType.Pinned = classType.Pinned;
+
+                    _injectedFieldTypes[(fieldType, fieldAttributes)] = duplicatedType.Pointer;
+                    fieldTypePtr = duplicatedType.Pointer;
+                }
+
+                fieldInfo.Type = (Il2CppTypeStruct*)fieldTypePtr;
+                if (fieldInfoClass == IntPtr.Zero)
+                    throw new Exception($"Type {fieldType} in {type}.{fieldsToInject[i].Name} doesn't exist in Il2Cpp");
+
+                if (IL2CPP.il2cpp_class_is_valuetype(fieldInfoClass)) {
+                    uint _align = 0;
+                    int fieldSize = IL2CPP.il2cpp_class_value_size(fieldInfoClass, ref _align);
+                    fieldOffset += fieldSize;
+                } else {
+                    fieldOffset += sizeof(Il2CppObject*);
+                }
+            }
+            classPointer.Fields = il2cppFields;
+
+            classPointer.InstanceSize = (uint)(fieldOffset + sizeof(InjectedClassData));
+            classPointer.ActualSize = classPointer.InstanceSize;
+
             var eligibleMethods = type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Where(IsMethodEligible).ToArray();
             var methodCount = 2 + eligibleMethods.Length; // 1 is the finalizer, 1 is empty ctor
 
@@ -225,7 +275,7 @@ namespace UnhollowerRuntimeLib
 
             methodPointerArray[0] = ConvertStaticMethod(FinalizeDelegate, "Finalize", classPointer);
             var finalizeMethod = UnityVersionHandler.Wrap(methodPointerArray[0]);
-            if (!type.IsAbstract) methodPointerArray[1] = ConvertStaticMethod(CreateEmptyCtor(type), ".ctor", classPointer);
+            if (!type.IsAbstract) methodPointerArray[1] = ConvertStaticMethod(CreateEmptyCtor(type, fieldsToInject), ".ctor", classPointer);
             Dictionary<(string name, int paramCount, bool isGeneric), int> infos = new Dictionary<(string, int, bool), int>(eligibleMethods.Length);
             for (var i = 0; i < eligibleMethods.Length; i++)
             {
@@ -373,7 +423,7 @@ namespace UnhollowerRuntimeLib
             classPointer.ByValArg.Data = classPointer.ThisArg.Data = (IntPtr)newCounter;
 
             RuntimeSpecificsStore.SetClassInfo(classPointer.Pointer, true, true);
-            WriteClassPointerForType(type, classPointer.Pointer);
+            Il2CppClassPointerStore.SetNativeClassPointer(type, classPointer.Pointer);
 
             AddToClassFromNameDictionary(type, classPointer.Pointer);
 
@@ -394,19 +444,6 @@ namespace UnhollowerRuntimeLib
             }
         }
 
-        internal static IntPtr ReadClassPointerForType(Type type)
-        {
-            if (type == typeof(void)) return Il2CppClassPointerStore<Void>.NativeClassPtr;
-            return (IntPtr)typeof(Il2CppClassPointerStore<>).MakeGenericType(type)
-                .GetField(nameof(Il2CppClassPointerStore<int>.NativeClassPtr)).GetValue(null);
-        }
-
-        internal static void WriteClassPointerForType(Type type, IntPtr value)
-        {
-            typeof(Il2CppClassPointerStore<>).MakeGenericType(type)
-                .GetField(nameof(Il2CppClassPointerStore<int>.NativeClassPtr)).SetValue(null, value);
-        }
-
         private static bool IsTypeSupported(Type type)
         {
             if (type.IsValueType ||
@@ -415,6 +452,14 @@ namespace UnhollowerRuntimeLib
             if (typeof(Il2CppSystem.ValueType).IsAssignableFrom(type)) return false;
 
             return typeof(Il2CppObjectBase).IsAssignableFrom(type);
+        }
+
+        private static bool IsFieldEligible(FieldInfo field) {
+            if (!field.FieldType.IsGenericType) return false;
+            Type genericTypeDef = field.FieldType.GetGenericTypeDefinition();
+            if (genericTypeDef != typeof(Il2CppReferenceField<>) && genericTypeDef != typeof(Il2CppValueField<>)) return false;
+
+            return IsTypeSupported(field.FieldType.GenericTypeArguments[0]);
         }
 
         private static bool IsMethodEligible(MethodInfo method)
@@ -502,7 +547,7 @@ namespace UnhollowerRuntimeLib
                     }
                     var parameterType = parameterInfo.ParameterType;
                     if (!parameterType.IsGenericParameter)
-                        param.ParameterType = (Il2CppTypeStruct*)IL2CPP.il2cpp_class_get_type(ReadClassPointerForType(parameterType));
+                        param.ParameterType = (Il2CppTypeStruct*)IL2CPP.il2cpp_class_get_type(Il2CppClassPointerStore.GetNativeClassPointer(parameterType));
                     else
                     {
                         var type = UnityVersionHandler.NewType();
@@ -528,7 +573,7 @@ namespace UnhollowerRuntimeLib
             converted.Slot = ushort.MaxValue;
 
             if (!monoMethod.ReturnType.IsGenericParameter)
-                converted.ReturnType = (Il2CppTypeStruct*)IL2CPP.il2cpp_class_get_type(ReadClassPointerForType(monoMethod.ReturnType));
+                converted.ReturnType = (Il2CppTypeStruct*)IL2CPP.il2cpp_class_get_type(Il2CppClassPointerStore.GetNativeClassPointer(monoMethod.ReturnType));
             else
             {
                 var type = UnityVersionHandler.NewType();
@@ -542,7 +587,7 @@ namespace UnhollowerRuntimeLib
             return converted.MethodInfoPointer;
         }
 
-        private static VoidCtorDelegate CreateEmptyCtor(Type targetType)
+        private static VoidCtorDelegate CreateEmptyCtor(Type targetType, FieldInfo[] fieldsToInitialize)
         {
             var method = new DynamicMethod("FromIl2CppCtorDelegate", MethodAttributes.Public | MethodAttributes.Static, CallingConventions.Standard, typeof(void), new[] { typeof(IntPtr) }, targetType, true);
 
@@ -571,7 +616,17 @@ namespace UnhollowerRuntimeLib
                 body.Emit(OpCodes.Call, targetType.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, Array.Empty<ParameterModifier>())!);
                 body.Emit(OpCodes.Ldloc, local);
             }
-
+            foreach (FieldInfo field in fieldsToInitialize)
+            {
+                body.Emit(OpCodes.Dup);
+                body.Emit(OpCodes.Dup);
+                body.Emit(OpCodes.Ldstr, field.Name);
+                body.Emit(OpCodes.Newobj, field.FieldType.GetConstructor(
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null,
+                    new Type[] { typeof(Il2CppObjectBase), typeof(string) }, Array.Empty<ParameterModifier>())
+                );
+                body.Emit(OpCodes.Stfld, field);
+            }
             body.Emit(OpCodes.Call, typeof(ClassInjector).GetMethod(nameof(ProcessNewObject))!);
 
             body.Emit(OpCodes.Ret);
@@ -972,6 +1027,7 @@ namespace UnhollowerRuntimeLib
         private static long ourClassOverrideCounter = -2;
         private static readonly ConcurrentDictionary<long, IntPtr> FakeTokenClasses = new ConcurrentDictionary<long, IntPtr>();
 
+        private static readonly ConcurrentDictionary<(Type type, FieldAttributes attrs), IntPtr> _injectedFieldTypes = new();
         private static volatile TypeToClassDelegate ourOriginalTypeToClassMethod;
         private static readonly VoidCtorDelegate FinalizeDelegate = Finalize;
 

--- a/UnhollowerBaseLib/Il2CppArrayBase.cs
+++ b/UnhollowerBaseLib/Il2CppArrayBase.cs
@@ -16,9 +16,9 @@ namespace UnhollowerBaseLib
             var targetClassType = IL2CPP.il2cpp_array_class_get(nativeClassPtr, 1);
             if (targetClassType == IntPtr.Zero)
                 return;
-            
-            ClassInjector.WriteClassPointerForType(ownType, targetClassType);
-            ClassInjector.WriteClassPointerForType(typeof(Il2CppArrayBase<T>), targetClassType);
+
+            Il2CppClassPointerStore.SetNativeClassPointer(ownType, targetClassType);
+            Il2CppClassPointerStore.SetNativeClassPointer(typeof(Il2CppArrayBase<T>), targetClassType);
             Il2CppClassPointerStore<Il2CppArrayBase<T>>.CreatedTypeRedirect = ownType;
         }
 

--- a/UnhollowerBaseLib/Il2CppClassPointerStore.cs
+++ b/UnhollowerBaseLib/Il2CppClassPointerStore.cs
@@ -5,6 +5,27 @@ using UnhollowerBaseLib.Attributes;
 
 namespace UnhollowerBaseLib
 {
+    public static class Il2CppClassPointerStore
+    {
+        public static IntPtr GetNativeClassPointer(Type type)
+        {
+            if (type == typeof(void)) return Il2CppClassPointerStore<Il2CppSystem.Void>.NativeClassPtr;
+            if (type == typeof(Il2CppSystem.String)) return Il2CppClassPointerStore<string>.NativeClassPtr;
+            return (IntPtr)typeof(Il2CppClassPointerStore<>)
+                .MakeGenericType(type)
+                .GetField(nameof(Il2CppClassPointerStore<int>.NativeClassPtr))
+                .GetValue(null);
+        }
+
+        internal static void SetNativeClassPointer(Type type, IntPtr value)
+        {
+            typeof(Il2CppClassPointerStore<>)
+                .MakeGenericType(type)
+                .GetField(nameof(Il2CppClassPointerStore<int>.NativeClassPtr))
+                .SetValue(null, value);
+        }
+    }
+
     public static class Il2CppClassPointerStore<T>
     {
         public static IntPtr NativeClassPtr;

--- a/UnhollowerBaseLib/Il2CppObjectBase.cs
+++ b/UnhollowerBaseLib/Il2CppObjectBase.cs
@@ -8,6 +8,7 @@ namespace UnhollowerBaseLib
 {
     public class Il2CppObjectBase
     {
+        public IntPtr ObjectClass => IL2CPP.il2cpp_object_get_class(Pointer);
         public IntPtr Pointer
         {
             get

--- a/UnhollowerBaseLib/Il2CppReferenceField.cs
+++ b/UnhollowerBaseLib/Il2CppReferenceField.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using UnhollowerBaseLib;
+
+namespace UnhollowerRuntimeLib
+{
+    public unsafe class Il2CppReferenceField<TRefObj> where TRefObj : Il2CppObjectBase
+    {
+        internal Il2CppReferenceField(Il2CppObjectBase obj, string fieldName)
+        {
+            _obj = obj;
+            _fieldPtr = IL2CPP.GetIl2CppField(obj.ObjectClass, fieldName);
+        }
+
+        public TRefObj Get()
+        {
+            IntPtr ptr = *GetPointerToData();
+            if (ptr == IntPtr.Zero) return null;
+            return (TRefObj)Activator.CreateInstance(typeof(TRefObj), ptr);
+        }
+
+        public void Set(TRefObj value) => *GetPointerToData() = value.Pointer;
+
+        public static implicit operator TRefObj(Il2CppReferenceField<TRefObj> _this) => _this.Get();
+        public static implicit operator Il2CppReferenceField<TRefObj>(TRefObj _) => throw null;
+
+        private IntPtr* GetPointerToData() => (IntPtr*)(IL2CPP.Il2CppObjectBaseToPtrNotNull(_obj) + (int)IL2CPP.il2cpp_field_get_offset(_fieldPtr));
+
+        private readonly Il2CppObjectBase _obj;
+        private readonly IntPtr _fieldPtr;
+    }
+}

--- a/UnhollowerBaseLib/Il2CppType.cs
+++ b/UnhollowerBaseLib/Il2CppType.cs
@@ -27,7 +27,7 @@ namespace UnhollowerRuntimeLib
 
         public static Il2CppSystem.Type From(Type type, bool throwOnFailure)
         {
-            var pointer = ClassInjector.ReadClassPointerForType(type);
+            var pointer = Il2CppClassPointerStore.GetNativeClassPointer(type);
             return TypeFromPointerInternal(pointer, type.Name, throwOnFailure);
         }
 

--- a/UnhollowerBaseLib/Il2CppValueField.cs
+++ b/UnhollowerBaseLib/Il2CppValueField.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using UnhollowerBaseLib;
+
+namespace UnhollowerRuntimeLib
+{
+    public unsafe class Il2CppValueField<T> where T : unmanaged
+    {
+        internal Il2CppValueField(Il2CppObjectBase obj, string fieldName)
+        {
+            _obj = obj;
+            _fieldPtr = IL2CPP.GetIl2CppField(obj.ObjectClass, fieldName);
+        }
+
+        public T Get() => *GetPointerToData();
+        public void Set(T value) => *GetPointerToData() = value;
+
+        public static implicit operator T(Il2CppValueField<T> _this) => _this.Get();
+        public static implicit operator Il2CppValueField<T>(T _) => throw null;
+
+        private T* GetPointerToData() => (T*)(IL2CPP.Il2CppObjectBaseToPtrNotNull(_obj) + (int)IL2CPP.il2cpp_field_get_offset(_fieldPtr));
+
+        private readonly Il2CppObjectBase _obj;
+        private readonly IntPtr _fieldPtr;
+    }
+}

--- a/UnhollowerBaseLib/Runtime/ClassInjectorBase.cs
+++ b/UnhollowerBaseLib/Runtime/ClassInjectorBase.cs
@@ -3,6 +3,10 @@ using System.Runtime.InteropServices;
 
 namespace UnhollowerBaseLib.Runtime
 {
+    internal unsafe struct InjectedClassData
+    {
+        public IntPtr managedGcHandle;
+    }
     public static class ClassInjectorBase
     {
         public static object GetMonoObjectFromIl2CppPointer(IntPtr pointer)
@@ -11,13 +15,10 @@ namespace UnhollowerBaseLib.Runtime
             return GCHandle.FromIntPtr(gcHandle).Target;
         }
 
-        public static unsafe IntPtr GetGcHandlePtrFromIl2CppObject(IntPtr pointer)
-        {
-            if (pointer == IntPtr.Zero) throw new NullReferenceException();
-            var objectKlass = (Il2CppClass*) IL2CPP.il2cpp_object_get_class(pointer);
-            var targetGcHandlePointer = IntPtr.Add(pointer, (int) UnityVersionHandler.Wrap(objectKlass).InstanceSize - IntPtr.Size);
-            var gcHandle = *(IntPtr*) targetGcHandlePointer;
-            return gcHandle;
+        public static unsafe IntPtr GetGcHandlePtrFromIl2CppObject(IntPtr pointer) => GetInjectedData(pointer)->managedGcHandle;
+        internal static unsafe InjectedClassData* GetInjectedData(IntPtr objectPointer) {
+            Il2CppClass* pObjectClass = (Il2CppClass*)IL2CPP.il2cpp_object_get_class(objectPointer);
+            return (InjectedClassData*)(objectPointer + (int)UnityVersionHandler.Wrap(pObjectClass).InstanceSize - sizeof(InjectedClassData)).ToPointer();
         }
     }
 }

--- a/UnhollowerBaseLib/Runtime/StructHandlerInterfaces.cs
+++ b/UnhollowerBaseLib/Runtime/StructHandlerInterfaces.cs
@@ -2,7 +2,10 @@
 
 namespace UnhollowerBaseLib.Runtime
 {
-    public interface INativeStructHandler {}
+    public interface INativeStructHandler
+    {
+        public int Size();
+    }
     
     public interface INativeStruct
     {

--- a/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
+++ b/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
@@ -145,6 +145,7 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativeAssemblyStruct Wrap(Il2CppAssembly* assemblyPointer) =>
             assemblyStructHandler.Wrap(assemblyPointer);
 
+        public static unsafe int AssemblySize() => assemblyStructHandler.Size();
 
         //Classes
         public static INativeClassStruct NewClass(int vTableSlots) =>
@@ -153,6 +154,7 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativeClassStruct Wrap(Il2CppClass* classPointer) =>
             classStructHandler.Wrap(classPointer);
 
+        public static unsafe int ClassSize() => classStructHandler.Size();
 
         //Events
         public static INativeEventInfoStruct NewEvent() =>
@@ -161,6 +163,7 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativeEventInfoStruct Wrap(Il2CppEventInfo* eventInfoPointer) =>
             eventInfoStructHandler.Wrap(eventInfoPointer);
 
+        public static unsafe int EventSize() => eventInfoStructHandler.Size();
 
         //Exceptions
         public static INativeExceptionStruct NewException() =>
@@ -169,6 +172,7 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativeExceptionStruct Wrap(Il2CppException* exceptionPointer) =>
             exceptionStructHandler.Wrap(exceptionPointer);
 
+        public static unsafe int ExceptionSize() => exceptionStructHandler.Size();
 
         //Fields
         public static INativeFieldInfoStruct NewField() =>
@@ -177,6 +181,8 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativeFieldInfoStruct Wrap(Il2CppFieldInfo* fieldInfoPointer) =>
             fieldInfoStructHandler.Wrap(fieldInfoPointer);
 
+        public static unsafe int FieldInfoSize() => fieldInfoStructHandler.Size();
+
 
         //Images
         public static INativeImageStruct NewImage() =>
@@ -184,7 +190,8 @@ namespace UnhollowerBaseLib.Runtime
         
         public static unsafe INativeImageStruct Wrap(Il2CppImage* imagePointer) =>
             imageStructHandler.Wrap(imagePointer);
-        
+
+        public static unsafe int ImageSize() => imageStructHandler.Size();
 
         //Methods
         public static INativeMethodInfoStruct NewMethod() =>
@@ -193,6 +200,7 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativeMethodInfoStruct Wrap(Il2CppMethodInfo* methodPointer) =>
             methodInfoStructHandler.Wrap(methodPointer);
 
+        public static unsafe int MethodSize() => methodInfoStructHandler.Size();
         public static IntPtr GetMethodFromReflection(IntPtr method) =>
             methodInfoStructHandler.GetMethodFromReflection(method);
 
@@ -218,6 +226,7 @@ namespace UnhollowerBaseLib.Runtime
         public static unsafe INativePropertyInfoStruct Wrap(Il2CppPropertyInfo* propertyInfoPointer) =>
             propertyInfoStructHandler.Wrap(propertyInfoPointer);
 
+        public static unsafe int ParameterInfoSize() => parameterInfoStructHandler.Size();
 
         //Types
         public static INativeTypeStruct NewType() =>
@@ -225,5 +234,6 @@ namespace UnhollowerBaseLib.Runtime
 
         public static unsafe INativeTypeStruct Wrap(Il2CppTypeStruct* typePointer) =>
             typeStructHandler.Wrap(typePointer);
+        public static unsafe int TypeSize() => typeStructHandler.Size();
     }
 }

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeAssemblyStructHandler_16_0 : INativeAssemblyStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppAssembly_16_0);
         public INativeAssemblyStruct CreateNewAssemblyStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_20_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_20_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
     [ApplicableToUnityVersionsSince("5.3.3")]
     public unsafe class NativeAssemblyStructHandler_20_0 : INativeAssemblyStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppAssembly_20_0);
         public INativeAssemblyStruct CreateNewAssemblyStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_20_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_0_B.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
     [ApplicableToUnityVersionsSince("2018.1.0")]
     public unsafe class NativeAssemblyStructHandler_24_0_B : INativeAssemblyStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppAssembly_24_0_B);
         public INativeAssemblyStruct CreateNewAssemblyStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_24_0_B>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_1.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
     [ApplicableToUnityVersionsSince("2020.1.0")]
     public unsafe class NativeAssemblyStructHandler_24_1 : INativeAssemblyStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppAssembly_24_1);
         public INativeAssemblyStruct CreateNewAssemblyStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_24_1>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_4.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Assembly/Assembly_24_4.cs
@@ -8,6 +8,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Assembly
     [ApplicableToUnityVersionsSince("2020.1.11")]
     public unsafe class NativeAssemblyStructHandler_24_4 : INativeAssemblyStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppAssembly_24_4);
         public INativeAssemblyStruct CreateNewAssemblyStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppAssembly_24_4>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_16_0.cs
@@ -8,6 +8,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.3.0")]
     public class NativeClassStructHandler_16_0 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_16_0);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_16_0>() +
@@ -156,6 +157,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_16_0>(nameof(Il2CppClass_16_0.bitfield_1)).ToInt32();
 
@@ -230,6 +233,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_19_0.cs
@@ -8,6 +8,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.3.2")]
     public class NativeClassStructHandler_19_0 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_19_0);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_19_0>() +
@@ -157,6 +158,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_19_0>(nameof(Il2CppClass_19_0.bitfield_1)).ToInt32();
 
@@ -231,6 +234,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_20_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_20_0.cs
@@ -8,6 +8,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.3.3")]
     public class NativeClassStructHandler_20_0 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_20_0);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_20_0>() +
@@ -158,6 +159,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_20_0>(nameof(Il2CppClass_20_0.bitfield_1)).ToInt32();
 
@@ -232,6 +235,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_B.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.3.6")]
     public class NativeClassStructHandler_21_0_B : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_21_0_B);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_21_0_B>() +
@@ -157,6 +158,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_21_0_B>(nameof(Il2CppClass_21_0_B.bitfield_1)).ToInt32();
 
@@ -231,6 +234,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_C.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_21_0_C.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.4.4")]
     public class NativeClassStructHandler_21_0_C : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_21_0_C);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_21_0_C>() +
@@ -158,6 +159,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_21_0_C>(nameof(Il2CppClass_21_0_C.bitfield_1)).ToInt32();
 
@@ -233,6 +236,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
 
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 
             public ref Il2CppClass** ImplementedInterfaces => ref NativeClass->implementedInterfaces;

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_A.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_A.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.5.0")]
     public class NativeClassStructHandler_22_0_A : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_22_0_A);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_22_0_A>() +
@@ -157,6 +158,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_22_0_A>(nameof(Il2CppClass_22_0_A.bitfield_1)).ToInt32();
 
@@ -231,6 +234,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_22_0_B.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.5.1")]
     public class NativeClassStructHandler_22_0_B : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_22_0_B);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_22_0_B>() +
@@ -158,6 +159,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_22_0_B>(nameof(Il2CppClass_22_0_B.bitfield_1)).ToInt32();
 
@@ -232,6 +235,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_23_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_23_0.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("5.6.0")]
     public class NativeClassStructHandler_23_0 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_23_0);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_23_0>() +
@@ -160,6 +161,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_23_0>(nameof(Il2CppClass_23_0.bitfield_1)).ToInt32();
 
@@ -234,6 +237,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_B.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2018.1.0")]
     public class NativeClassStructHandler_24_0_B : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_24_0_B);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_24_0_B>() +
@@ -154,6 +155,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_24_0_B>(nameof(Il2CppClass_24_0_B.bitfield_1)).ToInt32();
 
@@ -232,6 +235,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_C.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_0_C.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2018.2.0")]
     public class NativeClassStructHandler_24_0_C : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_24_0_C);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_24_0_C>() +
@@ -155,6 +156,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref uint ActualSize => ref NativeClass->actualSize;
 
             public ref ushort MethodCount => ref NativeClass->method_count;
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
 
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_24_0_C>(nameof(Il2CppClass_24_0_C.bitfield_1)).ToInt32();
@@ -234,6 +237,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_A.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_A.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2018.3.0")]
     public class NativeClassStructHandler_24_1_A : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_24_1_A);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_24_1_A>() +
@@ -157,6 +158,9 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_24_1_A>(nameof(Il2CppClass_24_1_A.bitfield_1)).ToInt32();
 
@@ -234,6 +238,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_1_B.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2018.3.8")]
     public class NativeClassStructHandler_24_1_B : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_24_1_B);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_24_1_B>() +
@@ -158,6 +159,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_24_1_B>(nameof(Il2CppClass_24_1_B.bitfield_1)).ToInt32();
 
@@ -235,6 +238,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_24_2.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2019.1.0")]
     public class NativeClassStructHandler_24_2 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_24_2);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_24_2>() +
@@ -161,6 +162,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             private static int bitfield1offset =
                 Marshal.OffsetOf<Il2CppClass_24_2>(nameof(Il2CppClass_24_2.bitfield_1)).ToInt32();
 
@@ -238,6 +241,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_0.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2020.2.0")]
     public class NativeClassStructHandler_27_0 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_27_0);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_27_0>() +
@@ -166,6 +167,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             // public ref ClassBitfield1 Bitfield1 => ref NativeClass->bitfield_1;
 
             // public ref ClassBitfield2 Bitfield2 => ref NativeClass->bitfield_2;
@@ -247,6 +250,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_2.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2021.1.0")]
     public class NativeClassStructHandler_27_2 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_27_2);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_27_2>() +
@@ -166,6 +167,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             // public ref ClassBitfield1 Bitfield1 => ref NativeClass->bitfield_1;
 
             // public ref ClassBitfield2 Bitfield2 => ref NativeClass->bitfield_2;
@@ -262,6 +265,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Class_27_3.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
     [ApplicableToUnityVersionsSince("2021.2.0")]
     public class NativeClassStructHandler_27_3 : INativeClassStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppClass_27_3);
         public unsafe INativeClassStruct CreateNewClassStruct(int vTableSlots)
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppClass_27_3>() +
@@ -166,6 +167,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
 
             public ref ushort MethodCount => ref NativeClass->method_count;
 
+            public ref ushort FieldCount => ref NativeClass->field_count;
+
             // public ref ClassBitfield1 Bitfield1 => ref NativeClass->bitfield_1;
 
             // public ref ClassBitfield2 Bitfield2 => ref NativeClass->bitfield_2;
@@ -262,6 +265,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
             public ref Il2CppClass* CastClass => ref NativeClass->castClass;
 
             public ref Il2CppClass* Class => ref NativeClass->klass;
+
+            public ref Il2CppFieldInfo* Fields => ref NativeClass->fields;
 
             public ref Il2CppMethodInfo** Methods => ref NativeClass->methods;
 

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Interfaces.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Class/Interfaces.cs
@@ -25,6 +25,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
         ref int NativeSize { get; }
         ref uint ActualSize { get; }
         ref ushort MethodCount { get; }
+        ref ushort FieldCount { get; }
         ref Il2CppClassAttributes Flags { get; }
 
         bool ValueType { get; set; }
@@ -48,6 +49,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Class
         unsafe ref Il2CppClass* CastClass { get; }
         unsafe ref Il2CppClass* Class { get; }
 
+        unsafe ref Il2CppFieldInfo* Fields { get; }
         unsafe ref Il2CppMethodInfo** Methods { get; }
         unsafe ref Il2CppClass** ImplementedInterfaces { get; }
         unsafe ref Il2CppRuntimeInterfaceOffsetPair* InterfaceOffsets { get; }

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeEventInfoStructHandler_16_0 : INativeEventInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppEventInfo_16_0);
         public INativeEventInfoStruct CreateNewEventInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppEventInfo_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_19_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
     [ApplicableToUnityVersionsSince("5.3.2")]
     public unsafe class NativeEventInfoStructHandler_19_0 : INativeEventInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppEventInfo_19_0);
         public INativeEventInfoStruct CreateNewEventInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppEventInfo_19_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/EventInfo/EventInfo_24_1.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.EventInfo
     [ApplicableToUnityVersionsSince("2018.3.0")]
     public unsafe class NativeEventInfoStructHandler_24_1 : INativeEventInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppEventInfo_24_1);
         public INativeEventInfoStruct CreateNewEventInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppEventInfo_24_1>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Exception
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeExceptionStructHandler_16_0 : INativeExceptionStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppException_16_0);
         public INativeExceptionStruct CreateNewExceptionStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppException_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_21_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_21_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Exception
     [ApplicableToUnityVersionsSince("5.3.5")]
     public unsafe class NativeExceptionStructHandler_21_0 : INativeExceptionStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppException_21_0);
         public INativeExceptionStruct CreateNewExceptionStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppException_21_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_22_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_22_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Exception
     [ApplicableToUnityVersionsSince("5.5.0")]
     public unsafe class NativeExceptionStructHandler_22_0 : INativeExceptionStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppException_22_0);
         public INativeExceptionStruct CreateNewExceptionStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppException_22_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Exception/Exception_27_3.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Exception
     [ApplicableToUnityVersionsSince("2021.2.0")]
     public unsafe class NativeExceptionStructHandler_27_3 : INativeExceptionStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppException_27_3);
         public INativeExceptionStruct CreateNewExceptionStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppException_27_3>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeFieldInfoStructHandler_16_0 : INativeFieldInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppFieldInfo_16_0);
         public INativeFieldInfoStruct CreateNewFieldInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppFieldInfo_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_19_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
     [ApplicableToUnityVersionsSince("5.3.2")]
     public unsafe class NativeFieldInfoStructHandler_19_0 : INativeFieldInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppFieldInfo_19_0);
         public INativeFieldInfoStruct CreateNewFieldInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppFieldInfo_19_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/FieldInfo/FieldInfo_24_1.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo
     [ApplicableToUnityVersionsSince("2018.3.0")]
     public unsafe class NativeFieldInfoStructHandler_24_1 : INativeFieldInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppFieldInfo_24_1);
         public INativeFieldInfoStruct CreateNewFieldInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppFieldInfo_24_1>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeImageStructHandler_16_0 : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_16_0);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_19_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("5.3.2")]
     public unsafe class NativeImageStructHandler_19_0 : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_19_0);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_19_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_A.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_A.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("2017.2.0")]
     public unsafe class NativeImageStructHandler_24_0_A : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_24_0_A);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_24_0_A>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_B.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_B.cs
@@ -7,6 +7,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("2017.2.1")]
     public unsafe class NativeImageStructHandler_24_0_B : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_24_0_B);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_24_0_B>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_C.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_0_C.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("2018.1.0")]
     public unsafe class NativeImageStructHandler_24_0_C : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_24_0_C);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_24_0_C>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_1.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("2018.3.0")]
     public unsafe class NativeImageStructHandler_24_1 : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_24_1);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_24_1>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_24_2.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("2019.1.0")]
     public unsafe class NativeImageStructHandler_24_2 : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_24_2);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_24_2>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Image/Images_27_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Image
     [ApplicableToUnityVersionsSince("2020.2.0")]
     public unsafe class NativeImageStructHandler_27_0 : INativeImageStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppImage_27_0);
         public INativeImageStruct CreateNewImageStruct()
         {
             var pointer = (Il2CppImage_27_0*) Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppImage_27_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeMethodInfoStructHandler_16_0 : INativeMethodInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppMethodInfo_16_0);
         public INativeMethodInfoStruct CreateNewMethodStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppMethodInfo_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_24_1.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
     [ApplicableToUnityVersionsSince("2018.3.0")]
     public unsafe class NativeMethodInfoStructHandler_24_1 : INativeMethodInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppMethodInfo_24_1);
         public INativeMethodInfoStruct CreateNewMethodStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppMethodInfo_24_1>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/MethodInfo/MethodInfo_27_3.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo
     [ApplicableToUnityVersionsSince("2021.2.0")]
     public unsafe class NativeMethodInfoStructHandler_27_3 : INativeMethodInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppMethodInfo_27_3);
         public INativeMethodInfoStruct CreateNewMethodStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppMethodInfo_27_3>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
     [ApplicableToUnityVersionsSince("5.3.0")]
     internal class NativeParameterInfoStructHandler_16_0 : INativeParameterInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppParameterInfo_16_0);
         public unsafe Il2CppParameterInfo*[] CreateNewParameterInfoArray(int paramCount)
         {
             var ptr = (Il2CppParameterInfo_16_0*) Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppParameterInfo_16_0>() * paramCount);

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_24_1.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
     [ApplicableToUnityVersionsSince("2018.3.0")]
     internal class NativeParameterInfoStructHandler_24_1 : INativeParameterInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppParameterInfo_24_1);
         public unsafe Il2CppParameterInfo*[] CreateNewParameterInfoArray(int paramCount)
         {
             var ptr = (Il2CppParameterInfo_24_1*) Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppParameterInfo_24_1>() * paramCount);

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_27_3.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/ParameterInfo/ParameterInfo_27_3.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.ParameterInfo
     [ApplicableToUnityVersionsSince("2021.2.0")]
     internal class NativeParameterInfoStructHandler_27_3 : INativeParameterInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppParameterInfo_27_3);
         public unsafe Il2CppParameterInfo*[] CreateNewParameterInfoArray(int paramCount)
         {
             var ptr = (Il2CppParameterInfo_27_3*)Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppParameterInfo_27_3>() * paramCount);

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativePropertyInfoStructHandler_16_0 : INativePropertyInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppPropertyInfo_16_0);
         public INativePropertyInfoStruct CreateNewPropertyInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppPropertyInfo_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_19_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_19_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
     [ApplicableToUnityVersionsSince("5.3.2")]
     public unsafe class NativePropertyInfoStructHandler_19_0 : INativePropertyInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppPropertyInfo_19_0);
         public INativePropertyInfoStruct CreateNewPropertyInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppPropertyInfo_19_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_24_1.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/PropertyInfo/PropertyInfo_24_1.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.PropertyInfo
     [ApplicableToUnityVersionsSince("2018.3.0")]
     public unsafe class NativePropertyInfoStructHandler_24_1 : INativePropertyInfoStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppPropertyInfo_24_1);
         public INativePropertyInfoStruct CreateNewPropertyInfoStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppPropertyInfo_24_1>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Interfaces.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Interfaces.cs
@@ -17,6 +17,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
 
         ref IntPtr Data { get; }
 
+        ref ushort Attrs { get; }
+
         ref Il2CppTypeEnum Type { get; }
 
         bool ByRef { get; set; }

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_16_0.cs
@@ -71,6 +71,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
 
             public ref IntPtr Data => ref NativeType->data;
 
+            public ref ushort Attrs => ref NativeType->attrs;
+
             public ref Il2CppTypeEnum Type => ref NativeType->type;
 
             public bool ByRef

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_16_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_16_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
     [ApplicableToUnityVersionsSince("5.3.0")]
     public unsafe class NativeTypeStructHandler_16_0 : INativeTypeStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppType_16_0);
         public INativeTypeStruct CreateNewTypeStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppType_16_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_0.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
     [ApplicableToUnityVersionsSince("2020.2.0")]
     public unsafe class NativeTypeStructHandler_27_0 : INativeTypeStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppType_27_0);
         public INativeTypeStruct CreateNewTypeStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppType_27_0>());

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_0.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_0.cs
@@ -73,6 +73,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
 
             public ref IntPtr Data => ref NativeType->data;
 
+            public ref ushort Attrs => ref NativeType->attrs;
+
             public ref Il2CppTypeEnum Type => ref NativeType->type;
 
             public bool ByRef

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_2.cs
@@ -74,6 +74,8 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
 
             public ref IntPtr Data => ref NativeType->data;
 
+            public ref ushort Attrs => ref NativeType->attrs;
+
             public ref Il2CppTypeEnum Type => ref NativeType->type;
 
             public bool ByRef

--- a/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_2.cs
+++ b/UnhollowerBaseLib/Runtime/VersionSpecific/Type/Type_27_2.cs
@@ -6,6 +6,7 @@ namespace UnhollowerBaseLib.Runtime.VersionSpecific.Type
     [ApplicableToUnityVersionsSince("2021.1.0")]
     public unsafe class NativeTypeStructHandler_27_2 : INativeTypeStructHandler
     {
+        public unsafe int Size() => sizeof(Il2CppType_27_2);
         public INativeTypeStruct CreateNewTypeStruct()
         {
             var pointer = Marshal.AllocHGlobal(Marshal.SizeOf<Il2CppType_27_2>());


### PR DESCRIPTION
## Summary
#### Class Injection
Injects a class' fields and their corresponding il2cpp type with proper attributes set (attributes are required for asset bundle field serialization)
Adds `Il2CppReferenceField` and `Il2CppValueField` each responsible for wrapping an il2cpp field at runtime.
#### Native Classes
Adds extra `Size` methods to UnityVersionHandler for each struct handler.
Wraps `fields` and `field_count` in native classes.
Wraps `attrs` in native types.
#### QOL
Il2CppObjectBase now has a propery `ObjectClass` which returns the object's native class pointer.
Fixes an exception being thrown in ClassInjector when a class has no namespace.
ClassInjector now uses a struct `InjectedClassData` to store the managed gc handle instead of an IntPtr.
Il2CppClassPointerStore now has a non-generic version that handles getting the class pointers through reflection.

## Notes
`Il2CppSystem.String` reference types do not get deserialized correctly from asset bundles and do not persist after being set.
`Il2Cpp*Field` classes have a stub implicit operator to support future default value support but at the moment do nothing.

## Field Injection Example
Unity Editor Script
```cs
public class TestScript : MonoBehaviour {
    public string refString;
    public GameObject refGameObject;
    public long longValue;
}
```
Injection Script
```cs
public class TestScript : MonoBehaviour {
    public void Start() {
        Log.LogInfo($"refGameObject.name -> {refGameObject.Get().name}");
        Log.LogInfo($"longValue -> {longValue.Get()}");
    }
    // this is the only reference type that doesn't get serialized correctly
    public Il2CppReferenceField<Il2CppSystem.String> refString;
    public Il2CppReferenceField<GameObject> refGameObject;
    public Il2CppValueField<long> longValue;
}
```
