### PR TITLE
EnumInjector & Injection Refactor

### DIFF
--- a/UnhollowerBaseLib/Injection/EnumInjector.cs
+++ b/UnhollowerBaseLib/Injection/EnumInjector.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using UnhollowerBaseLib;
+using UnhollowerBaseLib.Runtime;
+using UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo;
+using UnhollowerBaseLib.Runtime.VersionSpecific.Type;
+using UnhollowerRuntimeLib.Injection;
+
+namespace UnhollowerRuntimeLib
+{
+    public unsafe static class EnumInjector
+    {
+        // fieldInfo : defaultValueBlob
+        private static readonly ConcurrentDictionary<IntPtr, IntPtr> s_DefaultValueOverrides = new();
+        internal static bool GetDefaultValueOverride(Il2CppFieldInfo* fieldInfo, out IntPtr defaultValueBlob)
+        {
+            return s_DefaultValueOverrides.TryGetValue((IntPtr)fieldInfo, out defaultValueBlob);
+        }
+        public static void InjectEnumValues<TEnum>(Dictionary<string, object> valuesToAdd) where TEnum : Enum
+            => InjectEnumValues(typeof(TEnum), valuesToAdd);
+        public static void InjectEnumValues(Type type, Dictionary<string, object> valuesToAdd)
+        {
+            if (type == null)
+                throw new ArgumentException($"Type argument cannot be null");
+            if (!type.IsEnum)
+                throw new ArgumentException($"Type argument needs to be an enum");
+
+            var enumPtr = Il2CppClassPointerStore.GetNativeClassPointer(type);
+            if (enumPtr == IntPtr.Zero)
+                throw new ArgumentException($"Type needs to be an Il2Cpp enum");
+
+            InjectorHelpers.Setup();
+
+            InjectorHelpers.ClassInit((Il2CppClass*)enumPtr);
+
+            var il2cppEnum = UnityVersionHandler.Wrap((Il2CppClass*)enumPtr);
+            int newFieldCount = il2cppEnum.FieldCount + valuesToAdd.Count;
+            Il2CppFieldInfo* newFields = (Il2CppFieldInfo*)Marshal.AllocHGlobal(newFieldCount * UnityVersionHandler.FieldInfoSize());
+
+            int fieldIdx;
+            for (fieldIdx = 0; fieldIdx < il2cppEnum.FieldCount; ++fieldIdx)
+            {
+                int offset = fieldIdx * UnityVersionHandler.FieldInfoSize();
+                var oldField = UnityVersionHandler.Wrap(il2cppEnum.Fields + offset);
+                var newField = UnityVersionHandler.Wrap(newFields + offset);
+
+                newField.Name = oldField.Name;
+                newField.Type = oldField.Type;
+                newField.Parent = oldField.Parent;
+                newField.Offset = oldField.Offset;
+
+                // Move the default value blob from the old field to the new one
+                if (s_DefaultValueOverrides.TryRemove((IntPtr)oldField.FieldInfoPointer, out IntPtr blob))
+                    s_DefaultValueOverrides[(IntPtr)newField.FieldInfoPointer] = blob;
+            }
+
+            var enumElementType = UnityVersionHandler.Wrap(il2cppEnum.ElementClass).ByValArg;
+
+            foreach (var newData in valuesToAdd)
+            {
+                int offset = fieldIdx * UnityVersionHandler.FieldInfoSize();
+                var newField = UnityVersionHandler.Wrap(newFields + offset);
+                newField.Name = Marshal.StringToHGlobalAnsi(newData.Key);
+                newField.Type = enumElementType.TypePointer;
+                newField.Parent = il2cppEnum.ClassPointer;
+                newField.Offset = 0;
+
+                CreateOrUpdateFieldDefaultValue(newField.FieldInfoPointer, enumElementType.TypePointer, newData.Value);
+
+                ++fieldIdx;
+            }
+
+            il2cppEnum.FieldCount = (ushort)newFieldCount;
+            il2cppEnum.Fields = newFields;
+
+            Il2CppSystem.RuntimeType runtimeEnumType = Il2CppType.TypeFromPointer(enumPtr).TryCast<Il2CppSystem.RuntimeType>();
+            if (runtimeEnumType != null)
+            {
+                // The mono runtime caches the enum names and values the first time they are requested, so we reset this cache
+                runtimeEnumType.GenericCache = null;
+            }
+        }
+
+        private static int GetEnumElementSize(Il2CppTypeEnum type)
+        {
+            return type switch
+            {
+                Il2CppTypeEnum.IL2CPP_TYPE_I1 => sizeof(sbyte),
+                Il2CppTypeEnum.IL2CPP_TYPE_U1 => sizeof(byte),
+
+                Il2CppTypeEnum.IL2CPP_TYPE_CHAR => sizeof(char),
+
+                Il2CppTypeEnum.IL2CPP_TYPE_I2 => sizeof(short),
+                Il2CppTypeEnum.IL2CPP_TYPE_U2 => sizeof(ushort),
+
+                Il2CppTypeEnum.IL2CPP_TYPE_I4 => sizeof(int),
+                Il2CppTypeEnum.IL2CPP_TYPE_U4 => sizeof(uint),
+
+                Il2CppTypeEnum.IL2CPP_TYPE_I8 => sizeof(long),
+                Il2CppTypeEnum.IL2CPP_TYPE_U8 => sizeof(ulong),
+
+                _ => throw new ArgumentException($"The type provided {type} is invalid")
+            };
+        }
+
+        private static IntPtr AllocateNewDefaultValueBlob(Il2CppTypeEnum type)
+        {
+            int size = GetEnumElementSize(type);
+            IntPtr blob = Marshal.AllocHGlobal(size);
+            LogSupport.Trace($"Allocated default value blob at 0x{blob.ToInt64():X2} of {size} for {type}");
+            return blob;
+        }
+
+        private static IntPtr CreateOrUpdateFieldDefaultValue(Il2CppFieldInfo* field, Il2CppTypeStruct* type, object value)
+        {
+            Il2CppTypeEnum typeEnum = UnityVersionHandler.Wrap(type).Type;
+
+            if (!GetDefaultValueOverride(field, out IntPtr newBlob))
+            {
+                newBlob = AllocateNewDefaultValueBlob(typeEnum);
+                s_DefaultValueOverrides[(IntPtr)field] = newBlob;
+            }
+
+            SetFieldDefaultValue(newBlob, typeEnum, value);
+            return newBlob;
+        }
+
+        private static void SetFieldDefaultValue(IntPtr blob, Il2CppTypeEnum type, object value)
+        {
+            long valueData = Convert.ToInt64(value);
+            switch (type)
+            {
+                case Il2CppTypeEnum.IL2CPP_TYPE_I1: *(sbyte*)blob = (sbyte)valueData; break;
+                case Il2CppTypeEnum.IL2CPP_TYPE_U1: *(byte*)blob = (byte)valueData; break;
+
+                case Il2CppTypeEnum.IL2CPP_TYPE_CHAR: *(char*)blob = (char)valueData; break;
+
+                case Il2CppTypeEnum.IL2CPP_TYPE_I2: *(short*)blob = (short)valueData; break;
+                case Il2CppTypeEnum.IL2CPP_TYPE_U2: *(ushort*)blob = (ushort)valueData; break;
+
+                case Il2CppTypeEnum.IL2CPP_TYPE_I4: *(int*)blob = (int)valueData; break;
+                case Il2CppTypeEnum.IL2CPP_TYPE_U4: *(uint*)blob = (uint)valueData; break;
+
+                case Il2CppTypeEnum.IL2CPP_TYPE_I8: *(long*)blob = valueData; break;
+                case Il2CppTypeEnum.IL2CPP_TYPE_U8: *(ulong*)blob = (ulong)valueData; break;
+
+                default: throw new ArgumentException($"The type provided {type} is invalid");
+            }
+        }
+
+        public static void RegisterEnumInIl2Cpp<TEnum>(bool logSuccess = true) where TEnum : Enum => RegisterEnumInIl2Cpp(typeof(TEnum), logSuccess);
+        public static void RegisterEnumInIl2Cpp(Type type, bool logSuccess = true)
+        {
+            if (type == null)
+                throw new ArgumentException($"Type argument cannot be null");
+
+            if (!type.IsEnum)
+                throw new ArgumentException($"Type argument needs to be an enum");
+
+            var enumPtr = Il2CppClassPointerStore.GetNativeClassPointer(type);
+            if (enumPtr != IntPtr.Zero)
+                return;
+
+            InjectorHelpers.Setup();
+
+            var baseEnum = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore<Il2CppSystem.Enum>.NativeClassPtr);
+
+            InjectorHelpers.ClassInit(baseEnum.ClassPointer);
+
+            var il2cppEnum = UnityVersionHandler.NewClass(baseEnum.VtableCount);
+            var elementClass = UnityVersionHandler.Wrap((Il2CppClass*)Il2CppClassPointerStore.GetNativeClassPointer(Enum.GetUnderlyingType(type)));
+
+            il2cppEnum.Image = InjectorHelpers.InjectedImage.ImagePointer;
+            il2cppEnum.Class = il2cppEnum.CastClass = il2cppEnum.ElementClass = elementClass.ClassPointer;
+            il2cppEnum.Parent = baseEnum.ClassPointer;
+            il2cppEnum.ActualSize = il2cppEnum.InstanceSize = (uint)(baseEnum.InstanceSize + GetEnumElementSize(elementClass.ByValArg.Type));
+            il2cppEnum.NativeSize = -1;
+
+            il2cppEnum.ValueType = true;
+            il2cppEnum.EnumType = true;
+            il2cppEnum.Initialized = true;
+            il2cppEnum.InitializedAndNoError = true;
+            il2cppEnum.SizeInited = true;
+            il2cppEnum.HasFinalize = true;
+            il2cppEnum.IsVtableInitialized = true;
+
+            il2cppEnum.Name = Marshal.StringToHGlobalAnsi(type.Name);
+            il2cppEnum.Namespace = Marshal.StringToHGlobalAnsi(type.Namespace ?? string.Empty);
+
+            long token = InjectorHelpers.CreateClassToken(il2cppEnum.Pointer);
+            il2cppEnum.ThisArg.Data = il2cppEnum.ByValArg.Data = (IntPtr)token;
+
+            // Has to be IL2CPP_TYPE_VALUETYPE because IL2CPP_TYPE_ENUM isn't used
+            il2cppEnum.ThisArg.Type = il2cppEnum.ByValArg.Type = Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE;
+
+            il2cppEnum.Flags = (Il2CppClassAttributes)type.Attributes;
+
+            il2cppEnum.VtableCount = baseEnum.VtableCount;
+            var vtable = (VirtualInvokeData*)il2cppEnum.VTable;
+            var baseVTable = (VirtualInvokeData*)baseEnum.VTable;
+            for (int i = 0; i < baseEnum.VtableCount; i++)
+                vtable[i] = baseVTable[i];
+
+            var enumValues = Enum.GetValues(type);
+            string[] enumNames = Enum.GetNames(type);
+            il2cppEnum.FieldCount = (ushort)(enumValues.Length + 1); // value__
+
+            Il2CppFieldInfo* il2cppFields = (Il2CppFieldInfo*)Marshal.AllocHGlobal(il2cppEnum.FieldCount * UnityVersionHandler.FieldInfoSize());
+            var valueField = UnityVersionHandler.Wrap(il2cppFields);
+            valueField.Name = value__Cached;
+            valueField.Parent = il2cppEnum.ClassPointer;
+            valueField.Offset = (int)baseEnum.InstanceSize;
+
+            INativeTypeStruct enumValueType = UnityVersionHandler.NewType();
+            enumValueType.Data = elementClass.ThisArg.Data;
+            enumValueType.Attrs = (ushort)(FieldAttributes.Private | FieldAttributes.Family | FieldAttributes.SpecialName | FieldAttributes.RTSpecialName);
+            enumValueType.Type = elementClass.ThisArg.Type;
+            enumValueType.ByRef = elementClass.ThisArg.ByRef;
+            enumValueType.Pinned = elementClass.ThisArg.Pinned;
+
+            valueField.Type = enumValueType.TypePointer;
+
+            INativeTypeStruct enumConstType = UnityVersionHandler.NewType();
+            enumConstType.Data = il2cppEnum.ThisArg.Data;
+            enumConstType.Attrs = (ushort)(FieldAttributes.Private | FieldAttributes.Family | FieldAttributes.InitOnly | FieldAttributes.Literal | FieldAttributes.HasDefault);
+            enumConstType.Type = Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE;
+            enumConstType.ByRef = false;
+            enumConstType.Pinned = false;
+
+            for (int i = 1; i < il2cppEnum.FieldCount; i++)
+            {
+                object fieldValue = enumValues.GetValue(i - 1);
+                INativeFieldInfoStruct il2cppField = UnityVersionHandler.Wrap(il2cppFields + (i * UnityVersionHandler.FieldInfoSize()));
+                il2cppField.Name = Marshal.StringToHGlobalAnsi(enumNames[i - 1]);
+                il2cppField.Type = enumConstType.TypePointer;
+                il2cppField.Parent = il2cppEnum.ClassPointer;
+                il2cppField.Offset = 0;
+
+                CreateOrUpdateFieldDefaultValue(il2cppField.FieldInfoPointer, elementClass.ThisArg.TypePointer, fieldValue);
+            }
+
+            il2cppEnum.Fields = il2cppFields;
+
+            il2cppEnum.TypeHierarchyDepth = (byte)(1 + baseEnum.TypeHierarchyDepth);
+            il2cppEnum.TypeHierarchy = (Il2CppClass**)Marshal.AllocHGlobal(il2cppEnum.TypeHierarchyDepth * sizeof(void*));
+            for (var i = 0; i < il2cppEnum.TypeHierarchyDepth; i++)
+                il2cppEnum.TypeHierarchy[i] = baseEnum.TypeHierarchy[i];
+            il2cppEnum.TypeHierarchy[il2cppEnum.TypeHierarchyDepth - 1] = il2cppEnum.ClassPointer;
+
+            RuntimeSpecificsStore.SetClassInfo(il2cppEnum.Pointer, true, true);
+            Il2CppClassPointerStore.SetNativeClassPointer(type, il2cppEnum.Pointer);
+
+            InjectorHelpers.AddTypeToLookup(type, il2cppEnum.Pointer);
+
+            if (logSuccess) LogSupport.Info($"Registered managed enum {type} in il2cpp domain");
+        }
+
+        private static readonly IntPtr value__Cached = Marshal.StringToHGlobalAnsi("value__");
+    }
+}

--- a/UnhollowerBaseLib/Injection/InjectorHelpers.cs
+++ b/UnhollowerBaseLib/Injection/InjectorHelpers.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using UnhollowerBaseLib;
+using UnhollowerBaseLib.Runtime;
+using UnhollowerBaseLib.Runtime.VersionSpecific.Assembly;
+using UnhollowerBaseLib.Runtime.VersionSpecific.Class;
+using UnhollowerBaseLib.Runtime.VersionSpecific.FieldInfo;
+using UnhollowerBaseLib.Runtime.VersionSpecific.Image;
+using UnhollowerRuntimeLib.XrefScans;
+
+namespace UnhollowerRuntimeLib.Injection
+{
+    internal static unsafe class InjectorHelpers
+    {
+        internal static INativeAssemblyStruct InjectedAssembly;
+        internal static INativeImageStruct InjectedImage;
+        internal static ProcessModule Il2CppModule = Process.GetCurrentProcess()
+            .Modules.OfType<ProcessModule>()
+            .Single((x) => x.ModuleName == "GameAssembly.dll" || x.ModuleName == "UserAssembly.dll");
+
+        private static void CreateInjectedAssembly()
+        {
+            InjectedAssembly = UnityVersionHandler.NewAssembly();
+            InjectedImage = UnityVersionHandler.NewImage();
+
+            InjectedAssembly.Name = Marshal.StringToHGlobalAnsi("InjectedMonoTypes");
+
+            InjectedImage.Assembly = InjectedAssembly.AssemblyPointer;
+            InjectedImage.Dynamic = 1;
+            InjectedImage.Name = InjectedAssembly.Name;
+            if (InjectedImage.HasNameNoExt)
+                InjectedImage.NameNoExt = InjectedAssembly.Name;
+        }
+
+        internal static void Setup()
+        {
+            if (InjectedAssembly == null) CreateInjectedAssembly();
+            GetTypeInfoFromTypeDefinitionIndex ??= FindGetTypeInfoFromTypeDefinitionIndex();
+            ClassGetFieldDefaultValue ??= FindClassGetFieldDefaultValue();
+            ClassInit ??= FindClassInit();
+            ClassFromIl2CppType ??= FindClassFromIl2CppType();
+            ClassFromName ??= FindClassFromName();
+        }
+
+        internal static long CreateClassToken(IntPtr classPointer)
+        {
+            long newToken = Interlocked.Decrement(ref s_LastInjectedToken);
+            s_InjectedClasses[newToken] = classPointer;
+            return newToken;
+        }
+
+        internal static void AddTypeToLookup<T>(IntPtr typePointer) where T : class => AddTypeToLookup(typeof(T), typePointer);
+        internal static void AddTypeToLookup(Type type, IntPtr typePointer)
+        {
+            string klass = type.Name;
+            if (klass == null) return;
+            string namespaze = type.Namespace ?? string.Empty;
+            var attribute = Attribute.GetCustomAttribute(type, typeof(UnhollowerBaseLib.Attributes.ClassInjectionAssemblyTargetAttribute)) as UnhollowerBaseLib.Attributes.ClassInjectionAssemblyTargetAttribute;
+
+            foreach (IntPtr image in (attribute is null) ? IL2CPP.GetIl2CppImages() : attribute.GetImagePointers())
+            {
+                s_ClassNameLookup.Add((namespaze, klass, image), typePointer);
+            }
+        }
+
+        internal static IntPtr GetIl2CppExport(string exportName, bool throwIfNotExist = true)
+        {
+            IntPtr addr = GetProcAddress(Il2CppModule.BaseAddress, exportName);
+            if (addr == IntPtr.Zero && throwIfNotExist)
+                throw new NotSupportedException($"Couldn't find {exportName} in {Il2CppModule.ModuleName}'s exports");
+            return addr;
+        }
+
+        private static long s_LastInjectedToken = -2;
+        private static readonly ConcurrentDictionary<long, IntPtr> s_InjectedClasses = new();
+        /// <summary> (namespace, class, image) : class </summary>
+        private static readonly Dictionary<(string _namespace, string _class, IntPtr imagePtr), IntPtr> s_ClassNameLookup = new();
+
+        #region Class::FromName
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* d_ClassFromName(Il2CppImage* image, IntPtr _namespace, IntPtr name);
+        private static Il2CppClass* hkClassFromName(Il2CppImage* image, IntPtr _namespace, IntPtr name)
+        {
+            while (ClassFromNameOriginal == null) Thread.Sleep(1);
+            Il2CppClass* classPtr = ClassFromNameOriginal(image, _namespace, name);
+
+            if (classPtr == null)
+            {
+                string namespaze = Marshal.PtrToStringAnsi(_namespace);
+                string klass = Marshal.PtrToStringAnsi(name);
+                s_ClassNameLookup.TryGetValue((namespaze, klass, name), out IntPtr injectedClass);
+                classPtr = (Il2CppClass*)injectedClass;
+            }
+
+            return classPtr;
+        }
+        internal static d_ClassFromName ClassFromName;
+        internal static d_ClassFromName ClassFromNameOriginal;
+        private static d_ClassFromName FindClassFromName()
+        {
+            var classFromNameAPI = GetIl2CppExport(nameof(IL2CPP.il2cpp_class_from_name));
+            LogSupport.Trace($"il2cpp_class_from_name: 0x{classFromNameAPI.ToInt64():X2}");
+
+            var classFromName = XrefScannerLowLevel.JumpTargets(classFromNameAPI).Single();
+            LogSupport.Trace($"Class::FromName: 0x{classFromName.ToInt64():X2}");
+
+            ClassFromNameOriginal = ClassInjector.Detour.Detour(classFromName, new d_ClassFromName(hkClassFromName));
+            return Marshal.GetDelegateForFunctionPointer<d_ClassFromName>(classFromName);
+        }
+        #endregion
+
+        #region MetadataCache::GetTypeInfoFromTypeDefinitionIndex
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* d_GetTypeInfoFromTypeDefinitionIndex(int index);
+        private static Il2CppClass* hkGetTypeInfoFromTypeDefinitionIndex(int index)
+        {
+            if (s_InjectedClasses.TryGetValue(index, out IntPtr classPtr))
+                return (Il2CppClass*)classPtr;
+
+            while (GetTypeInfoFromTypeDefinitionIndexOriginal == null) Thread.Sleep(1);
+            return GetTypeInfoFromTypeDefinitionIndexOriginal(index);
+        }
+        internal static d_GetTypeInfoFromTypeDefinitionIndex GetTypeInfoFromTypeDefinitionIndex;
+        internal static d_GetTypeInfoFromTypeDefinitionIndex GetTypeInfoFromTypeDefinitionIndexOriginal;
+        private static d_GetTypeInfoFromTypeDefinitionIndex FindGetTypeInfoFromTypeDefinitionIndex()
+        {
+            var imageGetClassAPI = GetIl2CppExport(nameof(IL2CPP.il2cpp_image_get_class));
+            LogSupport.Trace($"il2cpp_image_get_class: 0x{imageGetClassAPI.ToInt64():X2}");
+
+            var imageGetType = XrefScannerLowLevel.JumpTargets(imageGetClassAPI).Single();
+            LogSupport.Trace($"Image::GetType: 0x{imageGetType.ToInt64():X2}");
+
+            var getTypeInfoFromTypeDefinitionIndex = XrefScannerLowLevel.JumpTargets(imageGetType).Single();
+            LogSupport.Trace($"MetadataCache::GetTypeInfoFromTypeDefinitionIndex: 0x{getTypeInfoFromTypeDefinitionIndex.ToInt64():X2}");
+
+            GetTypeInfoFromTypeDefinitionIndexOriginal = ClassInjector.Detour.Detour<d_GetTypeInfoFromTypeDefinitionIndex>(
+                getTypeInfoFromTypeDefinitionIndex,
+                hkGetTypeInfoFromTypeDefinitionIndex
+            );
+            return Marshal.GetDelegateForFunctionPointer<d_GetTypeInfoFromTypeDefinitionIndex>(getTypeInfoFromTypeDefinitionIndex);
+        }
+        #endregion
+
+        #region Class::FromIl2CppType
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate Il2CppClass* d_ClassFromIl2CppType(Il2CppTypeStruct* type);
+        private static Il2CppClass* hkClassFromIl2CppType(Il2CppTypeStruct* type)
+        {
+            var wrappedType = UnityVersionHandler.Wrap(type);
+            if ((long)wrappedType.Data < 0 && (wrappedType.Type == Il2CppTypeEnum.IL2CPP_TYPE_CLASS || wrappedType.Type == Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE))
+            {
+                s_InjectedClasses.TryGetValue((long)wrappedType.Data, out var classPointer);
+                return (Il2CppClass*)classPointer;
+            }
+
+            while (ClassFromIl2CppTypeOriginal == null) Thread.Sleep(1);
+            return ClassFromIl2CppTypeOriginal(type);
+        }
+        internal static d_ClassFromIl2CppType ClassFromIl2CppType;
+        internal static d_ClassFromIl2CppType ClassFromIl2CppTypeOriginal;
+        private static d_ClassFromIl2CppType FindClassFromIl2CppType()
+        {
+            var classFromTypeAPI = GetIl2CppExport(nameof(IL2CPP.il2cpp_class_from_il2cpp_type));
+            LogSupport.Trace($"il2cpp_class_from_il2cpp_type: 0x{classFromTypeAPI.ToInt64():X2}");
+
+            var classFromType = XrefScannerLowLevel.JumpTargets(classFromTypeAPI).Single();
+            LogSupport.Trace($"Class::FromIl2CppType: 0x{classFromType.ToInt64():X2}");
+
+            ClassFromIl2CppTypeOriginal = ClassInjector.Detour.Detour(classFromType, new d_ClassFromIl2CppType(hkClassFromIl2CppType));
+            return Marshal.GetDelegateForFunctionPointer<d_ClassFromIl2CppType>(classFromType);
+        }
+        #endregion
+
+        #region Class::GetFieldDefaultValue
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate byte* d_ClassGetFieldDefaultValue(Il2CppFieldInfo* field, out Il2CppTypeStruct* type);
+        private static byte* hkClassGetFieldDefaultValue(Il2CppFieldInfo* field, out Il2CppTypeStruct* type)
+        {
+            if (EnumInjector.GetDefaultValueOverride(field, out IntPtr newDefaultPtr))
+            {
+                INativeFieldInfoStruct wrappedField = UnityVersionHandler.Wrap(field);
+                INativeClassStruct wrappedParent = UnityVersionHandler.Wrap(wrappedField.Parent);
+                INativeClassStruct wrappedElementClass = UnityVersionHandler.Wrap(wrappedParent.ElementClass);
+                type = wrappedElementClass.ByValArg.TypePointer;
+                return (byte*)newDefaultPtr;
+            }
+            while (ClassGetFieldDefaultValueOriginal == null) Thread.Sleep(1);
+            return ClassGetFieldDefaultValueOriginal(field, out type);
+        }
+        internal static d_ClassGetFieldDefaultValue ClassGetFieldDefaultValue;
+        internal static d_ClassGetFieldDefaultValue ClassGetFieldDefaultValueOriginal;
+        private static d_ClassGetFieldDefaultValue FindClassGetFieldDefaultValue()
+        {
+            var getStaticFieldValueAPI = GetIl2CppExport(nameof(IL2CPP.il2cpp_field_static_get_value));
+            LogSupport.Trace($"il2cpp_field_static_get_value: 0x{getStaticFieldValueAPI.ToInt64():X2}");
+
+            var getStaticFieldValue = XrefScannerLowLevel.JumpTargets(getStaticFieldValueAPI).Single();
+            LogSupport.Trace($"Field::StaticGetValue: 0x{getStaticFieldValue.ToInt64():X2}");
+
+            var getStaticFieldValueInternal = XrefScannerLowLevel.JumpTargets(getStaticFieldValue).Last();
+            LogSupport.Trace($"Field::StaticGetValueInternal: 0x{getStaticFieldValueInternal.ToInt64():X2}");
+
+            // (Kasuromi): The invocation is Field::GetDefaultFieldValue, but this appears to get inlined in all the il2cpp assemblies I've looked at
+            // TODO: Add support for non-inlined method invocation
+            var classGetDefaultFieldValue = XrefScannerLowLevel.JumpTargets(getStaticFieldValueInternal).First();
+            LogSupport.Trace($"Class::GetDefaultFieldValue: 0x{classGetDefaultFieldValue.ToInt64():X2}");
+
+            ClassGetFieldDefaultValueOriginal = ClassInjector.Detour.Detour(classGetDefaultFieldValue, new d_ClassGetFieldDefaultValue(hkClassGetFieldDefaultValue));
+            return Marshal.GetDelegateForFunctionPointer<d_ClassGetFieldDefaultValue>(classGetDefaultFieldValue);
+        }
+        #endregion
+
+        #region Class::Init
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void d_ClassInit(Il2CppClass* klass);
+        internal static d_ClassInit ClassInit;
+
+        private static readonly MemoryUtils.SignatureDefinition[] s_ClassInitSignatures =
+        {
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x28\x83",
+                mask = "x????xxxxx",
+                xref = true
+            },
+            new MemoryUtils.SignatureDefinition
+            {
+                pattern = "\xE8\x00\x00\x00\x00\x0F\xB7\x47\x48\x48",
+                mask = "x????xxxxx",
+                xref = true
+            }
+        };
+
+        private static d_ClassInit FindClassInit()
+        {
+            nint pClassInit = s_ClassInitSignatures
+                .Select(s => MemoryUtils.FindSignatureInModule(Il2CppModule, s))
+                .FirstOrDefault(p => p != 0);
+
+            if (pClassInit == 0)
+            {
+                // WARN: There might be a race condition with il2cpp_class_has_references
+                LogSupport.Warning("Class::Init signatures have been exhausted, using il2cpp_class_has_references as a substitute!");
+                pClassInit = GetIl2CppExport(nameof(IL2CPP.il2cpp_class_has_references));
+                if (pClassInit == 0)
+                {
+                    LogSupport.Trace($"GameAssembly.dll: 0x{(long)Il2CppModule.BaseAddress}");
+                    throw new NotSupportedException("Failed to use signature for Class::Init and il2cpp_class_has_references cannot be found, please create an issue and report your unity version & game");
+                }
+            }
+
+            LogSupport.Trace($"Class::Init: 0x{(long)pClassInit:X2}");
+
+            return Marshal.GetDelegateForFunctionPointer<d_ClassInit>(pClassInit);
+        }
+        #endregion
+
+        #region Imports
+        [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
+        internal static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+        #endregion
+    }
+}

--- a/UnhollowerRuntimeLib/Forwarders.cs
+++ b/UnhollowerRuntimeLib/Forwarders.cs
@@ -8,6 +8,7 @@ using UnhollowerRuntimeLib.XrefScans;
 [assembly:TypeForwardedTo(typeof(Il2CppTypeOf<>))]
 [assembly:TypeForwardedTo(typeof(RuntimeReflectionHelper))]
 [assembly:TypeForwardedTo(typeof(ClassInjector))]
+[assembly:TypeForwardedTo(typeof(EnumInjector))]
 [assembly:TypeForwardedTo(typeof(DelegateSupport))]
 [assembly:TypeForwardedTo(typeof(XrefInstance))]
 [assembly:TypeForwardedTo(typeof(XrefScanner))]


### PR DESCRIPTION
## Summary
#### Enum Injection
Method for injecting user-specified values into an existing il2cpp enum
Method for injecting managed enums into the il2cpp domain
#### Injector Helpers
Uses a managed way of pulling the il2cpp module's base address
Injected assembly and image now reside in InjectorHelpers
Injected type lookups and tokens now reside in InjectorHelpers
#### Hooks
Hooks `Class::GetFieldDefaultValue` to support overriding field default values by bypassing il2cpp's metadata cache
Hooks `MetadataCache::GetTypeInfoFromTypeDefinitionIndex` as `Type::GetClass` uses it and it's necessary for creating enum arrays in the il2cpp runtime
Moved all existing hooks (except for `GenericMethod::GetMethod`) to InjectorHelpers

## Enum Value Injection Example
```cs
Il2CppSystem.Type fieldAttrType = Il2CppType.From(typeof(Il2CppSystem.Reflection.FieldAttributes));
Log("Before Modification: {string.Join(", ", (string[])Il2CppSystem.Enum.GetNames(fieldAttrType))}");
EnumInjector.InjectEnumValues(typeof(Il2CppSystem.Reflection.FieldAttributes), new()
{
    ["NewAttribute"] = 0xFFFFF
});
Log("After Modification: {string.Join(", ", (string[])Il2CppSystem.Enum.GetNames(fieldAttrType))}");

```
## Enum Injection Example
```cs
public enum InjectableEnum
{
    Value1 = 123,
    Value2 = 34444,
    Value3 = 49433
}

EnumInjector.RegisterEnumInIl2Cpp<InjectableEnum>();
Il2CppSystem.Type il2cppType = Il2CppType.From(typeof(InjectableEnum));

string[] enumNames = Il2CppSystem.Enum.GetNames(il2cppType);
Il2CppSystem.Array enumValues = Il2CppSystem.Enum.GetValues(il2cppType);

for (int i = 0; i < enumValues.Length; i++)
{
    Log("{enumNames[i]} -> {enumValues.GetValue(i).Unbox<InjectableEnum>()}");
}
```