### PR TITLE
Support pre v2018.3 in MetadataCache detours

### DIFF
--- a/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
+++ b/UnhollowerBaseLib/Runtime/UnityVersionHandler.cs
@@ -32,7 +32,7 @@ namespace UnhollowerBaseLib.Runtime
         private static readonly Dictionary<Type, List<(Version Version, object Handler)>> VersionedHandlers = new();
         private static readonly Dictionary<Type, object> Handlers = new();
 
-        private static Version UnityVersion = new(2018, 4, 20);
+        internal static Version UnityVersion = new(2018, 4, 20);
 
         public static bool IsMetadataV29OrHigher => UnityVersion >= new Version(2021, 2, 0);
         // Version since which extra_arg is set to invoke_multicast, necessitating constructor calls


### PR DESCRIPTION
## Summary
The unity version in `UnityVersionHandler` is exposed to the UnhollowerBaseLib assembly (should it be a public get?)
A `GetIl2CppMethodPointer` helper is introduced in InjectorHelpers to help with obtaining proxy function method pointers.

The approach for obtaining GetTypeInfoFromDefinitionIndex pre v2018.3 is to look for the `RuntimeHelpers::InitializeArray` icall at `icalls/mscorlib/System.Runtime.CompilerServices/RuntimeHelpers.cpp` through xrefing the proxy that invokes it because `il2cpp_resolve_icall` doesn't contain libil2cpp icalls.

The same approach does appear to work for higher unity versions, but because this is the first time we approach looking for icalls like this I have decided to keep both ways of obtaining it.
## Context
`il2cpp_image_get_class` which is the entrypoint we use to find GetTypeInfoFromDefinitionIndex is introduced in unity 2018.3.0f1 which would cause versions before 2018.3 to throw an exception in looking for the API function.