### PR TITLE
Rewrite IL2CPP Exception Stacktrace

### DIFF
--- a/UnhollowerBaseLib/Il2CppException.cs
+++ b/UnhollowerBaseLib/Il2CppException.cs
@@ -23,7 +23,7 @@ namespace UnhollowerBaseLib
             Il2CppSystem.Exception il2cppException = new(exception);
             return builtMessage + "\n" +
                 $"--- BEGIN IL2CPP STACK TRACE ---\n" +
-                $"{il2cppException}\n" +
+                $"{il2cppException.ToString(false, true)}\n" +
                 $"--- END IL2CPP STACK TRACE ---\n";
         }
 

--- a/UnhollowerBaseLib/Il2CppException.cs
+++ b/UnhollowerBaseLib/Il2CppException.cs
@@ -23,7 +23,7 @@ namespace UnhollowerBaseLib
             Il2CppSystem.Exception il2cppException = new(exception);
             return builtMessage + "\n" +
                 $"--- BEGIN IL2CPP STACK TRACE ---\n" +
-                $"{il2cppException.StackTrace}\n" +
+                $"{il2cppException}\n" +
                 $"--- END IL2CPP STACK TRACE ---\n";
         }
 


### PR DESCRIPTION
The stacktrace of an Il2CppSystem.Exception instance doesn't give the full stacktrace of the exception. For example, a `System.Reflection.TargetInvocationException` has an inner stack trace for the exception that caused it. The inner exception is not provided from `StackTrace`, but can be gotten by using `ToString()` on the Exception Instance.